### PR TITLE
chore: Use Ops.CollectStatus Event

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -83,6 +83,9 @@ async def test_given_charm_is_deployed_when_relate_to_mongo_and_certificates_the
 @pytest.mark.abort_on_fail
 async def test_remove_tls_and_wait_for_blocked_status(ops_test, build_and_deploy):
     await ops_test.model.remove_application(TLS_APPLICATION_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    # Running config-changed hook with empty config to check whether _tls_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APP_NAME].set_config({})
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
 
 
@@ -106,6 +109,9 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_a
 async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     assert ops_test.model
     await ops_test.model.remove_application(DB_APPLICATION_NAME, block_until_done=True)
+    # Running config-changed hook with empty config to check whether _database_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APP_NAME].set_config({})
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,8 +4,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from ops import testing
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 
 from charm import NRFOperatorCharm  # type: ignore[import]
 
@@ -77,10 +76,10 @@ class TestCharm(unittest.TestCase):
 
     def test_given_database_relation_not_created_when_pebble_ready_then_status_is_blocked(self):
         self.harness.container_pebble_ready(container_name="nrf")
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation to be created"),
+            BlockedStatus("Waiting for database relation"),
         )
 
     def test_given_certificates_relation_not_created_when_pebble_ready_then_status_is_blocked(
@@ -88,10 +87,10 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.container_pebble_ready(container_name="nrf")
         self._create_database_relation()
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation to be created"),
+            BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation"),
         )
 
     @patch("charm.check_output")
@@ -110,7 +109,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="nrf")
 
         self.harness.remove_relation(database_relation_id)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for database relation"),
@@ -122,6 +121,7 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for the database to be available"),
@@ -136,6 +136,7 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for database URI"),
@@ -147,6 +148,7 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for storage to be attached"),
@@ -168,6 +170,7 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready("nrf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for certificates to be stored"),
@@ -198,6 +201,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.charm._on_certificate_available(event=event)
         self.harness.container_pebble_ready(container_name="nrf")
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
         with open("tests/unit/expected_config/config.conf") as expected_config_file:
             expected_content = expected_config_file.read()
@@ -290,7 +294,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.container_pebble_ready("nrf")
-
+        self.harness.evaluate_status()
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     @patch("charm.check_output")
@@ -314,7 +318,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.container_pebble_ready("nrf")
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for pod IP address to be available"),
@@ -449,9 +453,10 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.charm._on_certificates_relation_broken(event=Mock())
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status,
-            BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation to be created"),
+            BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation"),
         )
 
     @patch(


### PR DESCRIPTION
# Description

This PR uses new ops feature CollectStatus Event to manage status Charm.  Event named "collect_unit_status" sets the status of charm automatically at the end of every hook.

Reference:
- https://ops.readthedocs.io/en/latest/#ops.CollectStatusEvent
- https://discourse.charmhub.io/t/how-to-set-a-charms-status/11771

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
