### PR TITLE
feat: TELCO-948 Use track for charm publication

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,6 +40,7 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
       charm-file-name: "sdcore-nrf-k8s_ubuntu-22.04-amd64.charm"
+      track-name: 1.3
     secrets: inherit
 
   lib-needs-publishing:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -10,6 +10,13 @@ on:
           - edge -> beta
           - beta -> candidate
           - candidate -> stable
+      track-name:
+        type: choice
+        description: Name of the charmhub track to publish
+        options:
+          - 1.3
+          - latest
+
 
 jobs:
   promote:
@@ -17,4 +24,6 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/promote.yaml@main
     with:
       promotion: ${{ github.event.inputs.promotion }}
+      track-name: ${{ github.event.inputs.track-name }}
+
     secrets: inherit


### PR DESCRIPTION
# Description

Adds a new variable for what track to use when publishing and publishing charms.

Depends on: https://github.com/canonical/sdcore-github-workflows/pull/24

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- N/A I have made corresponding changes to the documentation
- N/A I have added tests that validate the behaviour of the software
- N/A I validated that new and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library
