### PR TITLE
fix: Pinning Juju version to 3.3.0.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
-juju>=3.1
+juju==3.3.0.0
 macaroonbakery==1.3.4  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming


### PR DESCRIPTION
# Description

Pinning Juju version to` 3.3.0.0`. Starting from `3.3.1.0` integration tests are failing with
```shell
File "/home/runner/work/sdcore-nrf-k8s-operator/sdcore-nrf-k8s-operator/.tox/integration/lib/python3.10/site-packages/juju/version.py", line 19, in <module>
    CLIENT_VERSION = re.search(r'\d+\.\d+\.\d+', open(VERSION_FILE_PATH).read().strip()).group()
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/sdcore-nrf-k8s-operator/sdcore-nrf-k8s-operator/.tox/integration/lib/python3.10/site-packages/VERSION'
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
