### PR TITLE
chore: handle charm status with ops CollectStatus event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -95,6 +95,7 @@ class NRFOperatorCharm(CharmBase):
     def __init__(self, *args):
         """Initialize charm."""
         super().__init__(*args)
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         if not self.unit.is_leader():
             return
         self._container_name = self._service_name = "nrf"
@@ -106,7 +107,6 @@ class NRFOperatorCharm(CharmBase):
         self._certificates = TLSCertificatesRequiresV3(self, "certificates")
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
         self.unit.set_ports(NRF_SBI_PORT)
-        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         self.framework.observe(self.on.database_relation_joined, self._configure_nrf)
         self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(self.on.nrf_pebble_ready, self._configure_nrf)

--- a/src/charm.py
+++ b/src/charm.py
@@ -155,33 +155,42 @@ class NRFOperatorCharm(CharmBase):
             # teardown code is necessary to perform if we're removing the
             # charm.
             event.add_status(BlockedStatus("Scaling is not implemented for this charm"))
+            logger.info("Scaling is not implemented for this charm")
             return
         if not self._container.can_connect():
             event.add_status(WaitingStatus("Waiting for container to be ready"))
+            logger.info("Waiting for container to be ready")
             return
         for relation in [DATABASE_RELATION_NAME, "certificates"]:
             if not self._relation_created(relation):
                 event.add_status(BlockedStatus(f"Waiting for {relation} relation to be created"))
+                logger.info("Waiting for %s relation to be created", relation)
                 return
         if not self._database_is_available():
             event.add_status(WaitingStatus("Waiting for the database to be available"))
+            logger.info("Waiting for the database to be available")
             return
         if not self._get_database_uri():
             event.add_status(WaitingStatus("Waiting for database URI"))
+            logger.info("Waiting for database URI")
             return
         if not self._container.exists(path=BASE_CONFIG_PATH) or not self._container.exists(
             path=CERTS_DIR_PATH
         ):
             event.add_status(WaitingStatus("Waiting for storage to be attached"))
+            logger.info("Waiting for storage to be attached")
             return
         if not _get_pod_ip():
             event.add_status(WaitingStatus("Waiting for pod IP address to be available"))
+            logger.info("Waiting for pod IP address to be available")
             return
         if self._csr_is_stored() and not self._get_current_provider_certificate():
             event.add_status(WaitingStatus("Waiting for certificates to be stored"))
+            logger.info("Waiting for certificates to be stored")
             return
         if not self._nrf_service_is_running():
             event.add_status(WaitingStatus("Waiting for NRF service to start"))
+            logger.info("Waiting for NRF service to start")
             return
         event.add_status(ActiveStatus())
 
@@ -331,7 +340,7 @@ class NRFOperatorCharm(CharmBase):
     def _store_certificate(self, certificate: str) -> None:
         """Stores certificate in workload."""
         self._container.push(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}", source=certificate)
-        logger.info("Pushed certificate pushed to workload")
+        logger.info("Pushed certificate to workload")
 
     def _store_private_key(self, private_key: bytes) -> None:
         """Stores private key in workload."""
@@ -447,7 +456,7 @@ class NRFOperatorCharm(CharmBase):
         if not self._container.can_connect():
             return
         self._container.push(path=f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}", source=content)
-        logger.info("Pushed %s config file", CONFIG_FILE_NAME)
+        logger.info("Pushed %s config file to workload", CONFIG_FILE_NAME)
 
     def _database_is_available(self) -> bool:
         """Returns True if the database is available.

--- a/src/charm.py
+++ b/src/charm.py
@@ -96,11 +96,6 @@ class NRFOperatorCharm(CharmBase):
         """Initialize charm."""
         super().__init__(*args)
         if not self.unit.is_leader():
-            # NOTE: In cases where leader status is lost before the charm is
-            # finished processing all teardown events, this prevents teardown
-            # event code from running. Luckily, for this charm, none of the
-            # teardown code is necessary to preform if we're removing the
-            # charm.
             return
         self._container_name = self._service_name = "nrf"
         self._container = self.unit.get_container(self._container_name)
@@ -147,7 +142,7 @@ class NRFOperatorCharm(CharmBase):
             return False
         return True
 
-    def _on_collect_unit_status(self, event: CollectStatusEvent):
+    def _on_collect_unit_status(self, event: CollectStatusEvent):  # noqa C901
         """Check the unit status and set to Unit when CollectStatusEvent is fired.
 
         Args:
@@ -184,6 +179,9 @@ class NRFOperatorCharm(CharmBase):
             return
         if self._csr_is_stored() and not self._get_current_provider_certificate():
             event.add_status(WaitingStatus("Waiting for certificates to be stored"))
+            return
+        if not self._nrf_service_is_running():
+            event.add_status(WaitingStatus("Waiting for NRF service to start"))
             return
         event.add_status(ActiveStatus())
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -192,6 +192,7 @@ class NRFOperatorCharm(CharmBase):
             event: Juju event
         """
         if not self.ready_to_configure():
+            logger.info("The preconditions for the configuration are not met yet.")
             return
         if not self._private_key_is_stored():
             self._generate_private_key()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -154,7 +154,7 @@ async def test_when_scale_nrf_beyond_1_then_only_one_unit_is_active(
     await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_at_least_units=3)
     unit_statuses = Counter(unit.workload_status for unit in app.units)
     assert unit_statuses.get("active") == 1
-    assert unit_statuses.get("unknown") == 2
+    assert unit_statuses.get("blocked") == 2
 
 
 async def test_remove_nrf(ops_test: OpsTest, build_and_deploy):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -23,7 +23,6 @@ GRAFANA_AGENT_APPLICATION_NAME = "grafana-agent-k8s"
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def deploy_mongodb(ops_test):
     await ops_test.model.deploy(
         DB_CHARM_NAME, application_name=DB_APPLICATION_NAME, channel="6/beta", trust=True
@@ -31,7 +30,6 @@ async def deploy_mongodb(ops_test):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def deploy_grafana_agent(ops_test):
     await ops_test.model.deploy(
         GRAFANA_AGENT_APPLICATION_NAME,
@@ -41,7 +39,6 @@ async def deploy_grafana_agent(ops_test):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def deploy_self_signed_certificates(ops_test):
     await ops_test.model.deploy(
         TLS_APPLICATION_NAME,
@@ -51,7 +48,6 @@ async def deploy_self_signed_certificates(ops_test):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def build_and_deploy(ops_test):
     """Build the charm-under-test and deploy it together with related charms.
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -154,7 +154,7 @@ async def test_when_scale_nrf_beyond_1_then_only_one_unit_is_active(
     await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_at_least_units=3)
     unit_statuses = Counter(unit.workload_status for unit in app.units)
     assert unit_statuses.get("active") == 1
-    assert unit_statuses.get("blocked") == 2
+    assert unit_statuses.get("unknown") == 2
 
 
 async def test_remove_nrf(ops_test: OpsTest, build_and_deploy):


### PR DESCRIPTION
# Description

This PR aims to use new ops event `CollectStatus` to manage status in the charm. After the event named "collect_unit_status" (triggered after every hook), the callback sets the status of charm automatically.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
