### PR TITLE
chore: use collect status event to set blocked status on relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -108,7 +108,6 @@ class NRFOperatorCharm(CharmBase):
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
         self.unit.set_ports(NRF_SBI_PORT)
         self.framework.observe(self.on.database_relation_joined, self._configure_nrf)
-        self.framework.observe(self.on.database_relation_broken, self._on_database_relation_broken)
         self.framework.observe(self.on.nrf_pebble_ready, self._configure_nrf)
         self.framework.observe(self._database.on.database_created, self._configure_nrf)
         self.framework.observe(
@@ -238,14 +237,6 @@ class NRFOperatorCharm(CharmBase):
             logger.debug("Expiring certificate is not the one stored")
             return
         self._request_new_certificate()
-
-    def _on_database_relation_broken(self, event: EventBase) -> None:
-        """Event handler for database relation broken.
-
-        Args:
-            event: Juju event
-        """
-        self.unit.status = BlockedStatus("Waiting for database relation")
 
     def _get_current_provider_certificate(self) -> str | None:
         """Compares the current certificate request to what is in the interface.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -109,10 +109,11 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="nrf")
 
         self.harness.remove_relation(database_relation_id)
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation"),
+            BlockedStatus("Waiting for database relation to be created"),
         )
 
     def test_given_database_not_available_when_pebble_ready_then_status_is_waiting(


### PR DESCRIPTION
# Description

The `collect_unit_status` event is triggered after every hook. It will be triggered after db relation broken event. So we can remove the handler.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
