### PR TITLE
chore: Move to codespell and ruff

### DIFF
--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -146,7 +146,7 @@ class ProviderSchema(DataBagSchema):
 
 
 def data_matches_provider_schema(data: dict) -> bool:
-    """Returns whether data matches provider schema.
+    """Return whether data matches provider schema.
 
     Args:
         data (dict): Data to be validated.
@@ -171,11 +171,11 @@ class NRFAvailableEvent(EventBase):
         self.url = url
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {"url": self.url}
 
     def restore(self, snapshot: dict) -> None:
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.url = snapshot["url"]
 
 
@@ -208,7 +208,7 @@ class NRFRequires(Object):
         self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed event.
+        """Handle relation changed event.
 
         Args:
             event (RelationChangedEvent): Juju event.
@@ -220,7 +220,7 @@ class NRFRequires(Object):
             self.on.nrf_available.emit(url=remote_app_relation_data["url"])
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Handler triggered on the NRF relation broken event.
+        """Handle the NRF relation broken event.
 
         Args:
             event (RelationBrokenEvent): Juju event.
@@ -229,7 +229,7 @@ class NRFRequires(Object):
 
     @property
     def nrf_url(self) -> Optional[str]:
-        """Returns NRF url.
+        """Return NRF url.
 
         Returns:
             str: NRF url.
@@ -276,7 +276,7 @@ class NRFProvides(Object):
         url: str,
         relation_id: int,
     ) -> None:
-        """Sets NRF url in the application(s) relation data.
+        """Set NRF url in the application(s) relation data.
 
         Args:
             url (str): NRF url.
@@ -300,7 +300,7 @@ class NRFProvides(Object):
         relation.data[self.charm.app].update({"url": url})
 
     def set_nrf_information_in_all_relations(self, url: str) -> None:
-        """Sets NRF url in applications for all applications.
+        """Set NRF url in applications for all applications.
 
         Args:
             url (str): NRF url.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,27 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "lib/charms/data_platform_libs", "lib/charms/observability_libs"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
 
 # Ignore libraries that do not have type hint nor stubs
 [[tool.mypy.overrides]]
@@ -39,3 +41,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["charms.*"]
 follow_imports = "silent"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -49,7 +49,7 @@ LOGGING_RELATION_NAME = "logging"
 
 
 def _get_pod_ip() -> Optional[str]:
-    """Returns the pod IP using juju client.
+    """Return the pod IP using juju client.
 
     Returns:
         str: The pod IP.
@@ -65,7 +65,7 @@ def _render_config(
     nrf_sbi_port: int,
     scheme: str,
 ) -> str:
-    """Renders the nrfcfg config file.
+    """Render the nrfcfg config file.
 
     Args:
         database_name: Name of the database
@@ -123,7 +123,7 @@ class NRFOperatorCharm(CharmBase):
         )
 
     def ready_to_configure(self) -> bool:
-        """Returns whether all preconditions are met to proceed with configuration."""
+        """Return whether all preconditions are met to proceed with configuration."""
         if not self._container.can_connect():
             return False
         for relation in [DATABASE_RELATION_NAME, "certificates"]:
@@ -194,7 +194,7 @@ class NRFOperatorCharm(CharmBase):
         event.add_status(ActiveStatus())
 
     def _configure_nrf(self, event: EventBase) -> None:
-        """Adds pebble layer and manages Juju unit status.
+        """Add pebble layer and manages Juju unit status.
 
         Args:
             event: Juju event
@@ -220,7 +220,7 @@ class NRFOperatorCharm(CharmBase):
         self._publish_nrf_info_for_all_requirers()
 
     def _on_certificates_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Deletes TLS related artifacts and reconfigures workload."""
+        """Delete TLS related artifacts and reconfigures workload."""
         if not self._container.can_connect():
             event.defer()
             return
@@ -229,7 +229,7 @@ class NRFOperatorCharm(CharmBase):
         self._delete_certificate()
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
-        """Requests new certificate."""
+        """Request new certificate."""
         if not self._container.can_connect():
             event.defer()
             return
@@ -239,7 +239,7 @@ class NRFOperatorCharm(CharmBase):
         self._request_new_certificate()
 
     def _get_current_provider_certificate(self) -> str | None:
-        """Compares the current certificate request to what is in the interface.
+        """Compare the current certificate request to what is in the interface.
 
         Returns The current valid provider certificate if present
         """
@@ -250,7 +250,7 @@ class NRFOperatorCharm(CharmBase):
         return None
 
     def _is_certificate_update_required(self, provider_certificate) -> bool:
-        """Checks the provided certificate and existing certificate.
+        """Check the provided certificate and existing certificate.
 
         Returns True if update is required.
 
@@ -262,16 +262,16 @@ class NRFOperatorCharm(CharmBase):
         return self._get_existing_certificate() != provider_certificate
 
     def _get_existing_certificate(self) -> str:
-        """Returns the existing certificate if present else empty string."""
+        """Return the existing certificate if present else empty string."""
         return self._get_stored_certificate() if self._certificate_is_stored() else ""
 
     def _generate_private_key(self) -> None:
-        """Generates and stores private key."""
+        """Generate and stores private key."""
         private_key = generate_private_key()
         self._store_private_key(private_key)
 
     def _request_new_certificate(self) -> None:
-        """Generates and stores CSR, and uses to request new certificate."""
+        """Generate and store CSR, and use it to request new certificate."""
         private_key = self._get_stored_private_key()
         csr = generate_csr(
             private_key=private_key,
@@ -282,59 +282,59 @@ class NRFOperatorCharm(CharmBase):
         self._certificates.request_certificate_creation(certificate_signing_request=csr)
 
     def _delete_private_key(self):
-        """Removes private key from workload."""
+        """Remove private key from workload."""
         if not self._private_key_is_stored():
             return
         self._container.remove_path(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}")
         logger.info("Removed private key from workload")
 
     def _delete_csr(self):
-        """Deletes CSR from workload."""
+        """Delete CSR from workload."""
         if not self._csr_is_stored():
             return
         self._container.remove_path(path=f"{CERTS_DIR_PATH}/{CSR_NAME}")
         logger.info("Removed CSR from workload")
 
     def _delete_certificate(self):
-        """Deletes certificate from workload."""
+        """Delete certificate from workload."""
         if not self._certificate_is_stored():
             return
         self._container.remove_path(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}")
         logger.info("Removed certificate from workload")
 
     def _private_key_is_stored(self) -> bool:
-        """Returns whether private key is stored in workload."""
+        """Return whether private key is stored in workload."""
         return self._container.exists(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}")
 
     def _csr_is_stored(self) -> bool:
-        """Returns whether CSR is stored in workload."""
+        """Return whether CSR is stored in workload."""
         return self._container.exists(path=f"{CERTS_DIR_PATH}/{CSR_NAME}")
 
     def _get_stored_certificate(self) -> str:
-        """Returns stored certificate."""
+        """Return stored certificate."""
         return str(self._container.pull(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}").read())
 
     def _get_stored_csr(self) -> str:
-        """Returns stored CSR."""
+        """Return stored CSR."""
         return str(self._container.pull(path=f"{CERTS_DIR_PATH}/{CSR_NAME}").read())
 
     def _get_stored_private_key(self) -> bytes:
-        """Returns stored private key."""
+        """Return stored private key."""
         return str(
             self._container.pull(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}").read()
         ).encode()
 
     def _certificate_is_stored(self) -> bool:
-        """Returns whether certificate is stored in workload."""
+        """Return whether certificate is stored in workload."""
         return self._container.exists(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}")
 
     def _store_certificate(self, certificate: str) -> None:
-        """Stores certificate in workload."""
+        """Store certificate in workload."""
         self._container.push(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}", source=certificate)
         logger.info("Pushed certificate to workload")
 
     def _store_private_key(self, private_key: bytes) -> None:
-        """Stores private key in workload."""
+        """Store private key in workload."""
         self._container.push(
             path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
             source=private_key.decode(),
@@ -342,14 +342,14 @@ class NRFOperatorCharm(CharmBase):
         logger.info("Pushed private key to workload")
 
     def _store_csr(self, csr: bytes) -> None:
-        """Stores CSR in workload."""
+        """Store CSR in workload."""
         self._container.push(path=f"{CERTS_DIR_PATH}/{CSR_NAME}", source=csr.decode().strip())
         logger.info("Pushed CSR to workload")
 
     def _generate_nrf_config_file(self) -> str:
-        """Handles creation of the NRF config file.
+        """Handle creation of the NRF config file.
 
-        Generates NRF config file based on a given template.
+        Generate NRF config file based on a given template.
 
         Returns:
             content (str): desired config file content.
@@ -363,7 +363,7 @@ class NRFOperatorCharm(CharmBase):
         )
 
     def _is_config_update_required(self, content: str) -> bool:
-        """Decides whether config update is required by checking existence and config content.
+        """Decide whether config update is required by checking existence and config content.
 
         Args:
             content (str): desired config file content
@@ -378,7 +378,7 @@ class NRFOperatorCharm(CharmBase):
         return False
 
     def _config_file_is_written(self) -> bool:
-        """Returns whether the config file was written to the workload container.
+        """Return whether the config file was written to the workload container.
 
         Returns:
             bool: Whether the config file was written.
@@ -386,7 +386,7 @@ class NRFOperatorCharm(CharmBase):
         return bool(self._container.exists(f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}"))
 
     def _configure_workload(self, restart: bool = False) -> None:
-        """Configures pebble layer for the nrf container."""
+        """Configure pebble layer for the nrf container."""
         plan = self._container.get_plan()
         layer = self._pebble_layer
         if plan.services != layer.services or restart:
@@ -394,7 +394,7 @@ class NRFOperatorCharm(CharmBase):
             self._container.restart(self._service_name)
 
     def _config_file_content_matches(self, content: str) -> bool:
-        """Returns whether the nrfcfg config file content matches the provided content.
+        """Return whether the nrfcfg config file content matches the provided content.
 
         Returns:
             bool: Whether the nrfcfg config file content matches
@@ -428,7 +428,7 @@ class NRFOperatorCharm(CharmBase):
         self.nrf_provider.set_nrf_information_in_all_relations(nrf_url)
 
     def _relation_created(self, relation_name: str) -> bool:
-        """Returns whether a given Juju relation was crated.
+        """Return whether a given Juju relation was created.
 
         Args:
             relation_name (str): Relation name
@@ -439,7 +439,7 @@ class NRFOperatorCharm(CharmBase):
         return bool(self.model.relations[relation_name])
 
     def _push_config_file(self, content: str) -> None:
-        """Pushes config file to workload.
+        """Push config file to workload.
 
         Args:
             content: config file content
@@ -450,7 +450,7 @@ class NRFOperatorCharm(CharmBase):
         logger.info("Pushed %s config file to workload", CONFIG_FILE_NAME)
 
     def _database_is_available(self) -> bool:
-        """Returns True if the database is available.
+        """Return True if the database is available.
 
         Returns:
             bool: True if the database is available.
@@ -458,7 +458,7 @@ class NRFOperatorCharm(CharmBase):
         return self._database.is_resource_created()
 
     def _database_info(self) -> dict:
-        """Returns the database data.
+        """Return the database data.
 
         Returns:
             Dict: The database data.
@@ -468,7 +468,7 @@ class NRFOperatorCharm(CharmBase):
         return self._database.fetch_relation_data()[self._database.relations[0].id]
 
     def _get_database_uri(self) -> str:
-        """Returns the database URI.
+        """Return the database URI.
 
         Returns:
             str: The database URI.
@@ -480,7 +480,7 @@ class NRFOperatorCharm(CharmBase):
 
     @property
     def _pebble_layer(self) -> Layer:
-        """Returns pebble layer for the charm.
+        """Return pebble layer for the charm.
 
         Returns:
             Layer: Pebble Layer
@@ -502,7 +502,7 @@ class NRFOperatorCharm(CharmBase):
 
     @property
     def _environment_variables(self) -> dict:
-        """Returns workload service environment variables.
+        """Return workload service environment variables.
 
         Returns:
             dict: Environment variables
@@ -516,7 +516,7 @@ class NRFOperatorCharm(CharmBase):
         }
 
     def _nrf_service_is_running(self) -> bool:
-        """Returns whether the NRF service is running.
+        """Return whether the NRF service is running.
 
         Returns:
             bool: Whether the NRF service is running.
@@ -531,7 +531,7 @@ class NRFOperatorCharm(CharmBase):
 
     @staticmethod
     def _get_nrf_url() -> str:
-        """Returns NRF URL."""
+        """Return NRF URL."""
         return f"https://nrf:{NRF_SBI_PORT}"
 
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,15 +1,12 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju==3.4.0.0
 macaroonbakery==1.3.4  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
+ruff
 types-PyYAML
 types-setuptools
 types-toml

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -3,7 +3,6 @@ coverage[toml]
 juju==3.4.0.0
 macaroonbakery==1.3.4  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
-pep8-naming
 pytest
 pytest-operator
 ruff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r test-requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -18,16 +16,19 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.2.6
+    # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
@@ -35,15 +36,7 @@ decorator==5.1.1
 executing==2.0.1
     # via stack-data
 flake8==6.1.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.4.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
+    # via pep8-naming
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -51,17 +44,19 @@ hvac==2.1.0
 idna==3.6
     # via requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.1
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via
     #   -r test-requirements.in
@@ -73,7 +68,9 @@ macaroonbakery==1.3.4
     #   -r test-requirements.in
     #   juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
 mccabe==0.7.0
@@ -82,7 +79,6 @@ mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
-    #   black
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
@@ -91,23 +87,21 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   black
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
 pep8-naming==0.13.3
     # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
@@ -126,9 +120,9 @@ pyasn1-modules==0.3.0
 pycodestyle==2.11.1
     # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
+    # via
+    #   -c requirements.txt
+    #   cffi
 pyflakes==3.1.0
     # via flake8
 pygments==2.17.2
@@ -140,14 +134,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==6.1.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -161,6 +154,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -174,6 +168,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.5
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -181,8 +177,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -199,6 +193,7 @@ types-toml==0.10.8.20240310
     # via -r test-requirements.in
 typing-extensions==4.10.0
     # via
+    #   -c requirements.txt
     #   mypy
     #   typing-inspect
 typing-inspect==0.9.0
@@ -210,6 +205,8 @@ urllib3==2.2.1
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -35,8 +35,6 @@ decorator==5.1.1
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==6.1.0
-    # via pep8-naming
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -73,8 +71,6 @@ markupsafe==2.1.5
     #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
@@ -94,8 +90,6 @@ paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
 pluggy==1.4.0
@@ -117,14 +111,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
     # via
     #   -c requirements.txt
     #   cffi
-pyflakes==3.1.0
-    # via flake8
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,11 +4,10 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from charm import NRFOperatorCharm
 from charms.tls_certificates_interface.v3.tls_certificates import ProviderCertificate
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
-
-from charm import NRFOperatorCharm
 
 DB_APPLICATION_NAME = "mongodb-k8s"
 BASE_CONFIG_PATH = "/etc/nrf"
@@ -60,7 +59,7 @@ class TestCharm(unittest.TestCase):
 
     @staticmethod
     def _read_file(path: str) -> str:
-        """Reads a file and returns as a string.
+        """Read a file and returns as a string.
 
         Args:
             path (str): path to the file.

--- a/tox.ini
+++ b/tox.ini
@@ -29,15 +29,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
