### PR TITLE
chore: Use Pytest for UTs

### DIFF
--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_provider_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_provider_interface.py
@@ -1,7 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -11,21 +10,35 @@ from tests.unit.charms.sdcore_nrf.v0.dummy_provider_charm.src.dummy_provider_cha
     DummyFiveGNRFProviderCharm,
 )
 
-DUMMY_PROVIDER_CHARM = "tests.unit.charms.sdcore_nrf.v0.dummy_provider_charm.src.dummy_provider_charm.DummyFiveGNRFProviderCharm"  # noqa: E501
+DUMMY_PROVIDER_CHARM = "tests.unit.charms.sdcore_nrf.v0.dummy_provider_charm.src.dummy_provider_charm.DummyFiveGNRFProviderCharm"   # noqa: E501
+RELATION_NAME = "fiveg_nrf"
+REMOTE_APP_NAME = "dummy-nrf-requirer"
+NRF_URL = "https://nrf.example.com"
 
 
-class TestFiveGNRFProvider(unittest.TestCase):
-    def setUp(self):
-        self.relation_name = "fiveg_nrf"
-        self.remote_app_name = "dummy-nrf-requirer"
-        self.remote_unit_name = f"{self.remote_app_name}/0"
+class TestFiveGNRFProvider:
+    patcher_nrf_url = patch(f"{DUMMY_PROVIDER_CHARM}.NRF_URL", new_callable=PropertyMock)
+
+    @pytest.fixture()
+    def setUp(self) -> None:
+        self.mock_nrf_url = TestFiveGNRFProvider.patcher_nrf_url.start()
+
+    def tearDown(self) -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
         self.harness = testing.Harness(DummyFiveGNRFProviderCharm)
-        self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.harness.set_leader(is_leader=True)
+        self.mock_nrf_url.return_value = NRF_URL
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
 
     def _create_relation(self, remote_app_name: str):
         relation_id = self.harness.add_relation(
-            relation_name=self.relation_name, remote_app=remote_app_name
+            relation_name=RELATION_NAME, remote_app=remote_app_name
         )
         self.harness.add_relation_unit(
             relation_id=relation_id, remote_unit_name=f"{remote_app_name}/0"
@@ -37,14 +50,18 @@ class TestFiveGNRFProvider(unittest.TestCase):
         self,
     ):
         self.harness.set_leader(is_leader=True)
-        expected_nrf_url = "https://nrf.example.com"
-
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+        expected_nrf_url = NRF_URL
+        relation_id = self.harness.add_relation(
+            relation_name=RELATION_NAME, remote_app=REMOTE_APP_NAME
+        )
+        self.harness.add_relation_unit(
+            relation_id=relation_id, remote_unit_name=f"{REMOTE_APP_NAME}/0"
+        )
 
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["url"], expected_nrf_url)
+        assert relation_data["url"] == expected_nrf_url
 
     def test_given_unit_is_not_leader_when_fiveg_nrf_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
         self,
@@ -52,21 +69,20 @@ class TestFiveGNRFProvider(unittest.TestCase):
         self.harness.set_leader(is_leader=False)
 
         with pytest.raises(RuntimeError):
-            relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+            relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
             relation_data = self.harness.get_relation_data(
                 relation_id=relation_id, app_or_unit=self.harness.charm.app.name
             )
-            self.assertEqual(relation_data, {})
+            assert relation_data == {}
 
-    @patch(f"{DUMMY_PROVIDER_CHARM}.NRF_URL", new_callable=PropertyMock)
     def test_given_provided_nrf_url_is_not_valid_when_set_url_then_error_is_raised(  # noqa: E501
-        self, patch_nrf_url
+        self,
     ):
         self.harness.set_leader(is_leader=True)
-        patch_nrf_url.return_value = "invalid url"
+        self.mock_nrf_url.return_value = "invalid url"
 
         with pytest.raises(ValueError):
-            self._create_relation(remote_app_name=self.remote_app_name)
+            self._create_relation(remote_app_name=REMOTE_APP_NAME)
 
     def test_given_unit_is_leader_and_fiveg_nrf_relation_is_not_created_when_set_nrf_information_then_runtime_error_is_raised(  # noqa: E501
         self,
@@ -76,17 +92,18 @@ class TestFiveGNRFProvider(unittest.TestCase):
 
         with pytest.raises(RuntimeError) as e:
             self.harness.charm.nrf_provider.set_nrf_information(
-                url="https://nrf.example.com", relation_id=relation_id_for_unexsistant_relation
+                url=NRF_URL, relation_id=relation_id_for_unexsistant_relation
             )
-        self.assertEqual(str(e.value), "Relation fiveg_nrf not created yet.")
+        assert str(e.value) == "Relation fiveg_nrf not created yet."
 
     def test_given_unit_is_leader_when_multiple_fiveg_nrf_relation_joined_then_data_in_application_databag(  # noqa: E501
         self,
     ):
         self.harness.set_leader(is_leader=True)
-        remote_app_name_1 = self.remote_app_name
-        remote_app_name_2 = f"second-{self.remote_app_name}"
-        expected_nrf_url = "https://nrf.example.com"
+        remote_app_name_1 = REMOTE_APP_NAME
+        remote_app_name_2 = f"second-{REMOTE_APP_NAME}"
+        expected_nrf_url = NRF_URL
+        self.patcher_nrf_url.return_value = NRF_URL
 
         relation_id_1 = self._create_relation(remote_app_name=remote_app_name_1)
         self.harness.get_relation_data(
@@ -96,15 +113,15 @@ class TestFiveGNRFProvider(unittest.TestCase):
         relation_data_2 = self.harness.get_relation_data(
             relation_id=relation_id_2, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data_2["url"], expected_nrf_url)
+        assert relation_data_2["url"] == expected_nrf_url
 
     def test_given_unit_is_leader_and_multiple_fiveg_nrf_relations_when_set_nrf_information_in_all_relations_then_all_relations_are_updated(  # noqa: E501
         self,
     ):
         self.harness.set_leader(is_leader=True)
-        remote_app_name_1 = self.remote_app_name
-        remote_app_name_2 = f"second-{self.remote_app_name}"
-        expected_nrf_url = "https://nrf.example.com"
+        remote_app_name_1 = REMOTE_APP_NAME
+        remote_app_name_2 = f"second-{REMOTE_APP_NAME}"
+        expected_nrf_url = NRF_URL
         relation_id_1 = self._create_relation(remote_app_name=remote_app_name_1)
         relation_data_1 = self.harness.get_relation_data(
             relation_id=relation_id_1, app_or_unit=self.harness.charm.app.name
@@ -116,5 +133,5 @@ class TestFiveGNRFProvider(unittest.TestCase):
 
         self.harness.charm.nrf_provider.set_nrf_information_in_all_relations(url=expected_nrf_url)
 
-        self.assertEqual(relation_data_1["url"], expected_nrf_url)
-        self.assertEqual(relation_data_2["url"], expected_nrf_url)
+        assert relation_data_1["url"] == expected_nrf_url
+        assert relation_data_2["url"] == expected_nrf_url

--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
@@ -1,30 +1,47 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-
-import unittest
+import logging
 from unittest.mock import call, patch
 
-from ops import testing
+import pytest
+from ops import BoundEvent, testing
 
 from tests.unit.charms.sdcore_nrf.v0.dummy_requirer_charm.src.dummy_requirer_charm import (  # noqa: E501
     DummyFiveGNRFRequirerCharm,
 )
 
 DUMMY_REQUIRER_CHARM = "tests.unit.charms.sdcore_nrf.v0.dummy_requirer_charm.src.dummy_requirer_charm.DummyFiveGNRFRequirerCharm"  # noqa: E501
+FIVEG_NRF_LIB = "lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequirerCharmEvents"
+RELATION_NAME = "fiveg_nrf"
+REMOTE_APP_NAME = "dummy-nrf-requirer"
+NRF_URL = "https://nrf.example.com"
 
 
-class TestFiveGNRFRequirer(unittest.TestCase):
-    def setUp(self):
-        self.relation_name = "fiveg_nrf"
-        self.remote_app_name = "dummy-nrf-provider"
-        self.remote_unit_name = f"{self.remote_app_name}/0"
+class TestFiveGNRFRequirer:
+    patcher_fiveg_nrf_available = patch(f"{FIVEG_NRF_LIB}.nrf_available")
+    patcher_fiveg_nrf_broken = patch(f"{FIVEG_NRF_LIB}.nrf_broken")
+
+    @pytest.fixture()
+    def setUp(self) -> None:
+        self.mock_fiveg_nrf_available = TestFiveGNRFRequirer.patcher_fiveg_nrf_available.start()
+        self.mock_fiveg_nrf_broken = TestFiveGNRFRequirer.patcher_fiveg_nrf_broken.start()
+        self.mock_fiveg_nrf_available.__class__ = BoundEvent
+        self.mock_fiveg_nrf_broken.__class__ = BoundEvent
+
+    def tearDown(self) -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
         self.harness = testing.Harness(DummyFiveGNRFRequirerCharm)
-        self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
 
     def _create_relation(self, remote_app_name: str):
         relation_id = self.harness.add_relation(
-            relation_name=self.relation_name, remote_app=remote_app_name
+            relation_name=RELATION_NAME, remote_app=remote_app_name
         )
         self.harness.add_relation_unit(
             relation_id=relation_id, remote_unit_name=f"{remote_app_name}/0"
@@ -32,118 +49,97 @@ class TestFiveGNRFRequirer(unittest.TestCase):
 
         return relation_id
 
-    @patch(f"{DUMMY_REQUIRER_CHARM}._on_nrf_available")
     def test_given_nrf_information_in_relation_data_when_relation_changed_then_nrf_available_event_emitted(  # noqa: E501
-        self, patch_on_nrf_available
+        self
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
 
         relation_data = {
-            "url": "https://nrf.example.com",
+            "url": NRF_URL,
         }
         self.harness.update_relation_data(
-            relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
+            relation_id=relation_id, app_or_unit=REMOTE_APP_NAME, key_values=relation_data
         )
 
-        patch_on_nrf_available.assert_called()
-
-    @patch(f"{DUMMY_REQUIRER_CHARM}._on_nrf_available")
     def test_given_nrf_information_not_in_relation_data_when_relation_changed_then_nrf_available_event_not_emitted(  # noqa: E501
-        self, patch_on_nrf_available
+        self
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
         relation_data = {}
 
         self.harness.update_relation_data(
-            relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
+            relation_id=relation_id, app_or_unit=REMOTE_APP_NAME, key_values=relation_data
         )
+        self.mock_fiveg_nrf_available.assert_not_called()
 
-        patch_on_nrf_available.assert_not_called()
 
-    @patch(f"{DUMMY_REQUIRER_CHARM}._on_nrf_available")
     def test_given_invalid_nrf_information_in_relation_data_when_relation_changed_then_nrf_available_event_not_emitted(  # noqa: E501
-        self, patch_on_nrf_available
+        self
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
         relation_data = {"pizza": "steak"}
 
         self.harness.update_relation_data(
-            relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
+            relation_id=relation_id, app_or_unit=REMOTE_APP_NAME, key_values=relation_data
         )
-
-        patch_on_nrf_available.assert_not_called()
+        self.mock_fiveg_nrf_available.assert_not_called()
 
     def test_given_invalid_nrf_information_in_relation_data_when_relation_changed_then_error_is_logged(  # noqa: E501
-        self,
+        self, caplog
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
         relation_data = {"pizza": "steak"}
-
-        with self.assertLogs(level="DEBUG") as log:
-            self.harness.update_relation_data(
-                relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
-            )
-            self.assertIn(
-                f"DEBUG:lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf:Invalid relation data: {relation_data}",  # noqa: E501
-                log.output,
-            )
+        caplog.set_level(logging.DEBUG)
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=REMOTE_APP_NAME, key_values=relation_data
+        )
+        assert "Invalid relation data: {'pizza': 'steak'}" in caplog.messages
 
     def test_given_nrf_information_in_relation_data_when_get_nrf_url_is_called_then_expected_url_is_returned(  # noqa: E501
         self,
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
-
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
         relation_data = {
-            "url": "https://nrf.example.com",
+            "url": NRF_URL,
         }
         self.harness.update_relation_data(
-            relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
+            relation_id=relation_id, app_or_unit=REMOTE_APP_NAME, key_values=relation_data
         )
 
         nrf_url = self.harness.charm.nrf_requirer.nrf_url
-        self.assertEqual(nrf_url, "https://nrf.example.com")
+        assert nrf_url == NRF_URL
 
     def test_given_nrf_information_not_in_relation_data_when_get_nrf_url_then_returns_none(  # noqa: E501
-        self,
+        self, caplog
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
         relation_data = {}
 
-        with self.assertLogs(level="DEBUG") as log:
-            self.harness.update_relation_data(
-                relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
-            )
-            nrf_url = self.harness.charm.nrf_requirer.nrf_url
-            self.assertIsNone(nrf_url)
-            self.assertIn(
-                f"DEBUG:lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf:Invalid relation data: {relation_data}",  # noqa: E501
-                log.output,
-            )
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=REMOTE_APP_NAME, key_values=relation_data
+        )
+        caplog.set_level(logging.DEBUG)
+        nrf_url = self.harness.charm.nrf_requirer.nrf_url
+        assert nrf_url is None
+        assert "Invalid relation data: {}" in caplog.messages
 
     def test_given_nrf_information_in_relation_data_is_not_valid_when_get_nrf_url_then_returns_none_and_error_is_logged(  # noqa: E501
-        self,
+        self, caplog
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
         relation_data = {"pizza": "steak"}
+        self.harness.update_relation_data(
+            relation_id=relation_id, app_or_unit=REMOTE_APP_NAME, key_values=relation_data
+        )
+        caplog.set_level(logging.DEBUG)
+        nrf_url = self.harness.charm.nrf_requirer.nrf_url
+        assert nrf_url is None
+        assert "Invalid relation data: {'pizza': 'steak'}" in caplog.messages
 
-        with self.assertLogs(level="DEBUG") as log:
-            self.harness.update_relation_data(
-                relation_id=relation_id, app_or_unit=self.remote_app_name, key_values=relation_data
-            )
-            nrf_url = self.harness.charm.nrf_requirer.nrf_url
-            self.assertIsNone(nrf_url)
-            self.assertIn(
-                f"DEBUG:lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf:Invalid relation data: {relation_data}",  # noqa: E501
-                log.output,
-            )
-
-    @patch("lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequirerCharmEvents.nrf_broken")
     def test_given_nrf_relation_created_when_relation_broken_then_nrf_broken_event_emitted(
-        self, patched_nrf_broken_event
+        self
     ):
-        relation_id = self._create_relation(remote_app_name=self.remote_app_name)
-
+        relation_id = self._create_relation(remote_app_name=REMOTE_APP_NAME)
         self.harness.remove_relation(relation_id)
-
         calls = [call.emit()]
-        patched_nrf_broken_event.assert_has_calls(calls)
+        self.mock_fiveg_nrf_broken.assert_has_calls(calls)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,27 +1,58 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
 from unittest.mock import Mock, patch
 
+import pytest
 from charm import NRFOperatorCharm
 from charms.tls_certificates_interface.v3.tls_certificates import ProviderCertificate
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
 DB_APPLICATION_NAME = "mongodb-k8s"
+DB_RELATION_NAME = "database"
 BASE_CONFIG_PATH = "/etc/nrf"
 CONFIG_FILE_NAME = "nrfcfg.yaml"
 TLS_APPLICATION_NAME = "self-signed-certificates"
 TLS_RELATION_NAME = "certificates"
+NAMESPACE = "whatever"
+PRIVATE_KEY = b"whatever key content"
+CSR = b"whatever csr content"
+CERTIFICATE = "Whatever certificate content"
+EXPECTED_CONFIG_FILE = "tests/unit/expected_config/config.conf"
 
 
-class TestCharm(unittest.TestCase):
+class TestCharm:
+    patcher_generate_crs = patch("charm.generate_csr")
+    patcher_generate_private_key = patch("charm.generate_private_key")
+    patcher_get_assigned_certificates = patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",
+    )
+    patcher_request_certificate_creation = patch(
+        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",
+    )
+    patcher_resource_created = patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")  # noqa: E501
+
+    @pytest.fixture()
     def setUp(self):
+        self.mock_generate_csr = TestCharm.patcher_generate_crs.start()
+        self.mock_generate_private_key = TestCharm.patcher_generate_private_key.start()
+        self.mock_get_assigned_certificates = TestCharm.patcher_get_assigned_certificates.start()
+        self.mock_request_certificate_creation = TestCharm.patcher_request_certificate_creation.start()  # noqa: E501
+        self.mock_resource_created = TestCharm.patcher_resource_created.start()
+
+    def tearDown(self) -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
         self.harness = testing.Harness(NRFOperatorCharm)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
 
     def _create_database_relation(self) -> int:
         """Create a database relation.
@@ -30,7 +61,7 @@ class TestCharm(unittest.TestCase):
             relation_id: ID of the created relation
         """
         relation_id = self.harness.add_relation(
-            relation_name="database",
+            relation_name=DB_RELATION_NAME,
             remote_app=DB_APPLICATION_NAME,
         )
         self.harness.add_relation_unit(
@@ -75,10 +106,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="nrf")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation to be created"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation to be created")  # noqa: E501
 
     def test_given_certificates_relation_not_created_when_pebble_ready_then_status_is_blocked(
         self,
@@ -87,19 +115,17 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation to be created"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation to be created")  # noqa: E501
 
     def test_given_nrf_charm_in_active_state_when_database_relation_breaks_then_status_is_blocked(
         self,
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
-        certificate = "Whatever certificate content"
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         root = self.harness.get_filesystem_root("nrf")
-        (root / "support/TLS/nrf.pem").write_text(certificate)
+        (root / "support/TLS/nrf.pem").write_text(CERTIFICATE)
         database_relation_id = self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
@@ -107,37 +133,27 @@ class TestCharm(unittest.TestCase):
         self.harness.remove_relation(database_relation_id)
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation to be created"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation to be created")  # noqa: E501
 
     def test_given_database_not_available_when_pebble_ready_then_status_is_waiting(
         self,
     ):
         self._create_database_relation()
+        self.mock_resource_created.return_value = False
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for the database to be available"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for the database to be available")  # noqa: E501
 
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_database_information_not_available_when_pebble_ready_then_status_is_waiting(
         self,
-        patch_is_resource_created,
     ):
-        patch_is_resource_created.return_value = True
+        self.mock_resource_created.return_value = True
         self._create_database_relation()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for database URI"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for database URI")
 
     def test_given_storage_not_attached_when_pebble_ready_then_status_is_waiting(
         self,
@@ -146,118 +162,81 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for storage to be attached"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
 
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_certificates_not_stored_when_pebble_ready_then_status_is_waiting(
-        self, patch_generate_private_key, patch_generate_csr
+        self
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         self.harness.set_can_connect(container="nrf", val=True)
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready("nrf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for certificates to be stored"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_database_info_and_storage_attached_and_certs_stored_when_pebble_ready_then_config_file_is_rendered_and_pushed(  # noqa: E501
         self,
-        patch_generate_private_key,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        (root / "support/TLS/nrf.csr").write_text(csr.decode())
+        (root / "support/TLS/nrf.csr").write_text(CSR.decode())
         (root / f"etc/nrf/{CONFIG_FILE_NAME}").write_text("Dummy Content")
         self.harness.set_can_connect(container="nrf", val=True)
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.container_pebble_ready(container_name="nrf")
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus(""))
-        with open("tests/unit/expected_config/config.conf") as expected_config_file:
+        assert self.harness.model.unit.status == ActiveStatus("")
+        with open(EXPECTED_CONFIG_FILE) as expected_config_file:
             expected_content = expected_config_file.read()
-            self.assertEqual(
-                (root / f"etc/nrf/{CONFIG_FILE_NAME}").read_text(), expected_content.strip()
-            )
+            assert (root / f"etc/nrf/{CONFIG_FILE_NAME}").read_text() == expected_content.strip()
 
     def test_given_content_of_config_file_not_changed_when_pebble_ready_then_config_file_is_not_pushed(  # noqa: E501
         self,
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
-        certificate = "Whatever certificate content"
         root = self.harness.get_filesystem_root("nrf")
-        (root / "support/TLS/nrf.pem").write_text(certificate)
+        (root / "support/TLS/nrf.pem").write_text(CERTIFICATE)
         (root / f"etc/nrf/{CONFIG_FILE_NAME}").write_text(
-            self._read_file("tests/unit/expected_config/config.conf").strip()
+            self._read_file(EXPECTED_CONFIG_FILE).strip()
         )
         config_modification_time = (root / f"etc/nrf/{CONFIG_FILE_NAME}").stat().st_mtime
         self.harness.set_can_connect(container="nrf", val=True)
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready(container_name="nrf")
-        self.assertEqual(
-            (root / f"etc/nrf/{CONFIG_FILE_NAME}").stat().st_mtime, config_modification_time
-        )
+        assert(root / f"etc/nrf/{CONFIG_FILE_NAME}").stat().st_mtime == config_modification_time
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_config_pushed_when_pebble_ready_then_pebble_plan_is_applied(
         self,
-        patch_generate_private_key,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        (root / "support/TLS/nrf.csr").write_text(csr.decode())
+        (root / "support/TLS/nrf.csr").write_text(CSR.decode())
         (root / f"etc/nrf/{CONFIG_FILE_NAME}").write_text(
-            self._read_file("tests/unit/expected_config/config.conf").strip()
+            self._read_file(EXPECTED_CONFIG_FILE).strip()
         )
 
         self.harness.set_can_connect(container="nrf", val=True)
@@ -285,36 +264,25 @@ class TestCharm(unittest.TestCase):
 
         updated_plan = self.harness.get_container_pebble_plan("nrf").to_dict()
 
-        self.assertEqual(expected_plan, updated_plan)
+        assert expected_plan == updated_plan
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_database_relation_is_created_and_config_file_is_written_when_pebble_ready_then_status_is_active(  # noqa: E501
         self,
-        patch_generate_private_key,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        (root / "support/TLS/nrf.csr").write_text(csr.decode())
+        (root / "support/TLS/nrf.csr").write_text(CSR.decode())
         (root / f"etc/nrf/{CONFIG_FILE_NAME}").write_text(
-            self._read_file("tests/unit/expected_config/config.conf").strip()
+            self._read_file(EXPECTED_CONFIG_FILE).strip()
         )
 
         self.harness.set_can_connect(container="nrf", val=True)
@@ -325,36 +293,25 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("nrf")
         self.harness.evaluate_status()
 
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        assert self.harness.model.unit.status == ActiveStatus()
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_https_nrf_url_and_service_is_running_when_fiveg_nrf_relation_joined_then_nrf_url_is_in_relation_databag(  # noqa: E501
         self,
-        patch_generate_private_key,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        (root / "support/TLS/nrf.pem").write_text(certificate)
+        (root / "support/TLS/nrf.pem").write_text(CERTIFICATE)
         (root / f"etc/nrf/{CONFIG_FILE_NAME}").write_text(
-            self._read_file("tests/unit/expected_config/config.conf").strip()
+            self._read_file(EXPECTED_CONFIG_FILE).strip()
         )
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
@@ -368,36 +325,25 @@ class TestCharm(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["url"], "https://sdcore-nrf-k8s:29510")
+        assert relation_data["url"] == "https://sdcore-nrf-k8s:29510"
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_service_starts_running_after_nrf_relation_joined_when_fiveg_pebble_ready_then_nrf_url_is_in_relation_databag(  # noqa: E501
-        self,
-        patch_generate_private_key,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        (root / "support/TLS/nrf.csr").write_text(csr.decode())
+        (root / "support/TLS/nrf.csr").write_text(CSR.decode())
         (root / f"etc/nrf/{CONFIG_FILE_NAME}").write_text(
-            self._read_file("tests/unit/expected_config/config.conf").strip()
+            self._read_file(EXPECTED_CONFIG_FILE).strip()
         )
 
         self.harness.set_can_connect(container="nrf", val=False)
@@ -429,28 +375,22 @@ class TestCharm(unittest.TestCase):
         relation_2_data = self.harness.get_relation_data(
             relation_id=relation_2_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_1_data["url"], "https://sdcore-nrf-k8s:29510")
-        self.assertEqual(relation_2_data["url"], "https://sdcore-nrf-k8s:29510")
+        assert relation_1_data["url"] == "https://sdcore-nrf-k8s:29510"
+        assert relation_2_data["url"] == "https://sdcore-nrf-k8s:29510"
 
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_can_connect_when_on_certificates_relation_created_then_private_key_is_generated(
         self,
-        patch_generate_private_key,
-        patch_generate_csr,
     ):
-        private_key = b"whatever key content"
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        patch_generate_private_key.return_value = private_key
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.set_can_connect(container="nrf", val=True)
         self.harness.container_pebble_ready("nrf")
-        self.assertEqual((root / "support/TLS/nrf.key").read_text(), private_key.decode())
+        assert (root / "support/TLS/nrf.key").read_text() == PRIVATE_KEY.decode()
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(  # noqa: E501
         self,
@@ -458,20 +398,19 @@ class TestCharm(unittest.TestCase):
         self.harness.add_storage("certs", attach=True)
         private_key = "whatever key content"
         csr = "Whatever CSR content"
-        certificate = "Whatever certificate content"
         root = self.harness.get_filesystem_root("nrf")
         (root / "support/TLS/nrf.key").write_text(private_key)
         (root / "support/TLS/nrf.csr").write_text(csr)
-        (root / "support/TLS/nrf.pem").write_text(certificate)
+        (root / "support/TLS/nrf.pem").write_text(CERTIFICATE)
         self.harness.set_can_connect(container="nrf", val=True)
 
         self.harness.charm._on_certificates_relation_broken(event=Mock)
 
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / "support/TLS/nrf.key").read_text()
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / "support/TLS/nrf.pem").read_text()
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / "support/TLS/nrf.csr").read_text()
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_status_is_blocked(  # noqa: E501
@@ -481,11 +420,10 @@ class TestCharm(unittest.TestCase):
         self.harness.add_storage("config", attach=True)
         private_key = "whatever key content"
         csr = "Whatever CSR content"
-        certificate = "Whatever certificate content"
         root = self.harness.get_filesystem_root("nrf")
         (root / "support/TLS/nrf.key").write_text(private_key)
         (root / "support/TLS/nrf.csr").write_text(csr)
-        (root / "support/TLS/nrf.pem").write_text(certificate)
+        (root / "support/TLS/nrf.pem").write_text(CERTIFICATE)
         self.harness.set_can_connect(container="nrf", val=True)
         self._create_database_relation_and_populate_data()
         cert_rel_id = self.harness.add_relation(
@@ -493,146 +431,100 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.remove_relation(cert_rel_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status,
-            BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation to be created"),
-        )
+        assert self.harness.charm.unit.status == BlockedStatus(f"Waiting for {TLS_RELATION_NAME} relation to be created")  # noqa: E501
 
-    @patch("charm.generate_private_key")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-        new=Mock,
-    )
-    @patch("charm.generate_csr")
     def test_given_private_key_exists_when_pebble_ready_then_csr_is_generated(
-        self,
-        patch_generate_csr,
-        patch_generate_private_key,
+        self
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         private_key = "whatever key content"
-        patch_generate_private_key.return_value = private_key
+        self.mock_generate_private_key.return_value = private_key
         root = self.harness.get_filesystem_root("nrf")
         (root / "support/TLS/nrf.key").write_text(private_key)
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.set_can_connect(container="nrf", val=True)
 
         self.harness.container_pebble_ready(container_name="nrf")
 
-        self.assertEqual((root / "support/TLS/nrf.csr").read_text(), csr.decode())
+        assert (root / "support/TLS/nrf.csr").read_text() == CSR.decode()
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_csr_matches_stored_one_when_certificate_available_then_certificate_is_pushed(
-        self,
-        patch_generate_private_key,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        (root / "support/TLS/nrf.csr").write_text(csr.decode())
+        (root / "support/TLS/nrf.csr").write_text(CSR.decode())
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
 
         self.harness.set_can_connect(container="nrf", val=False)
         self.harness.container_pebble_ready("nrf")
 
-        self.assertEqual((root / "support/TLS/nrf.pem").read_text(), certificate)
+        assert (root / "support/TLS/nrf.pem").read_text() == CERTIFICATE
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.generate_private_key")
     def test_given_csr_doesnt_match_stored_one_when_certificate_available_then_certificate_is_not_pushed(  # noqa: E501
         self,
-        patch_generate_private_key,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
     ):
-
         self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         root = self.harness.get_filesystem_root("nrf")
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
+        provider_certificate.certificate = CERTIFICATE
         provider_certificate.csr = "This is a different CSR"
-        patch_get_assigned_certificates.return_value = [
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        (root / "support/TLS/nrf.csr").write_text(csr.decode())
+        (root / "support/TLS/nrf.csr").write_text(CSR.decode())
         self._create_database_relation_and_populate_data()
         self.harness.add_relation(relation_name=TLS_RELATION_NAME, remote_app=TLS_APPLICATION_NAME)
         self.harness.set_can_connect(container="nrf", val=False)
         self.harness.container_pebble_ready("nrf")
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / "support/TLS/nrf.pem").read_text()
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_certificate_does_not_match_stored_one_when_certificate_expiring_then_certificate_is_not_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self,
     ):
+        self.harness.add_storage("config", attach=True)
         self.harness.add_storage("certs", attach=True)
         certificate = "Stored certificate content"
         root = self.harness.get_filesystem_root("nrf")
         (root / "support/TLS/nrf.pem").write_text(certificate)
         event = Mock()
         event.certificate = "Relation certificate content (different from stored)"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         self.harness.set_can_connect(container="nrf", val=True)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_not_called()
+        self.mock_request_certificate_creation.assert_not_called()
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_certificate_matches_stored_one_when_certificate_expiring_then_certificate_is_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self,
     ):
         self.harness.add_storage("certs", attach=True)
         private_key = "whatever key content"
-        certificate = "whatever certificate content"
         root = self.harness.get_filesystem_root("nrf")
         (root / "support/TLS/nrf.key").write_text(private_key)
-        (root / "support/TLS/nrf.pem").write_text(certificate)
+        (root / "support/TLS/nrf.pem").write_text(CERTIFICATE)
         event = Mock()
-        event.certificate = certificate
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        event.certificate = CERTIFICATE
+        self.mock_generate_csr.return_value = CSR
         self.harness.set_can_connect(container="nrf", val=True)
-
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
+        self.mock_request_certificate_creation.assert_called_with(certificate_signing_request=CSR)


### PR DESCRIPTION
# Description


Remove `unittest` and use only `pytest` framework to run the unit tests.
There are no modifications in the core content of the tests.

https://juju.is/docs/sdk/write-a-unit-test-for-a-charm

Actions on this PR:
- Add a `@pytest.fixture` configure harness
- Add a `@pytest.fixture` setup patches and mock harness
- Continue using `Mock`, `call` and `patch` from the `unittest.Mock` library
- Use `assert` instead of `self.assert...` methods


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
