### PR TITLE
chore: bump sdcore-github-workflows to 0.0.2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,37 +9,37 @@ on:
 jobs:
   codeql:
     name: CodeQL Analysis
-    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/codeql-analysis.yml@v0.0.2
     with:
       branch-name: ${{ github.ref }}
 
   check-libraries:
-    uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@v0.0.2
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
   lint-report:
-    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@v0.0.2
     with:
       branch-name: ${{ github.ref }}
 
   terraform-check:
-    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v0.0.2
     with:
       branch-name: ${{ github.ref }}
 
   static-analysis:
-    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/static-analysis.yaml@v0.0.2
     with:
       branch-name: ${{ github.ref }}
 
   unit-tests-with-coverage:
-    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/unit-test.yaml@v0.0.2
     with:
       branch-name: ${{ github.ref }}
 
   integration-test:
-    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@v0.0.2
     with:
       branch-name: ${{ github.ref }}
       charm-file-name: "sdcore-nrf-k8s_ubuntu-22.04-amd64.charm"
@@ -52,7 +52,23 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ github.ref_name == 'v1.4' }}
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v0.0.2
+    with:
+      branch-name: ${{ github.ref_name }}
+      charm-file-name: "sdcore-nrf-k8s_ubuntu-22.04-amd64.charm"
+      track-name: 1.4
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
+
+  publish-charm-on-push:
+    name: Publish Developer Charm To Branch
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+      - integration-test
+    if: ${{ (github.ref_name != 'v1.4') && (github.event_name == 'push') }}
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v0.0.2
     with:
       branch-name: ${{ github.ref_name }}
       charm-file-name: "sdcore-nrf-k8s_ubuntu-22.04-amd64.charm"


### PR DESCRIPTION
# Description
bump sdcore-github-workflows to 0.0.2  to fix the publishing issue which was not related to publishing the charm to the dev branch.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
