### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,3 @@ pytest
 pytest-asyncio>=v0.21.2 # https://github.com/pytest-dev/pytest/issues/12269
 pytest-operator
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,25 +12,29 @@ cachetools==5.5.0
     # via google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-durationpy==0.7
+durationpy==0.9
     # via kubernetes
 executing==2.1.0
     # via stack-data
@@ -39,17 +43,23 @@ google-auth==2.35.0
 hvac==2.3.0
     # via juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
     # via
     #   -r test-requirements.in
@@ -59,7 +69,9 @@ kubernetes==31.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
@@ -70,12 +82,9 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.5.0
@@ -85,7 +94,9 @@ parso==0.8.4
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.48
     # via ipython
 protobuf==5.28.2
@@ -102,7 +113,9 @@ pyasn1==0.6.1
 pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
@@ -116,10 +129,11 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -127,7 +141,7 @@ pytest-asyncio==0.21.2
     # via
     #   -r test-requirements.in
     #   pytest-operator
-pytest-operator==0.37.0
+pytest-operator==0.38.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
     # via kubernetes
@@ -135,10 +149,9 @@ pytz==2024.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
@@ -150,7 +163,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.6.8
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
@@ -169,6 +182,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
@@ -181,7 +195,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
     # via juju

--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_provider_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_provider_interface.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 from ops.charm import ActionEvent, CharmBase
 
 from lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
@@ -54,7 +54,7 @@ class TestFiveGNRFProvider:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFiveGNRFProviderCharm,
             meta={
                 "name": "nrf-provider-charm",
@@ -71,11 +71,11 @@ class TestFiveGNRFProvider:
     def test_given_unit_is_leader_when_set_nrf_information_then_data_is_in_application_databag(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[nrf_relation],
         )
@@ -94,11 +94,11 @@ class TestFiveGNRFProvider:
     def test_given_unit_is_not_leader_when_set_nrf_information_then_data_is_not_in_application_databag(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
             relations=[nrf_relation],
         )
@@ -115,11 +115,11 @@ class TestFiveGNRFProvider:
     def test_given_provided_nrf_url_is_not_valid_when_set_nrf_information_then_error_is_raised(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[nrf_relation],
         )
@@ -136,7 +136,7 @@ class TestFiveGNRFProvider:
     def test_given_unit_is_leader_and_fiveg_nrf_relation_is_not_created_when_set_nrf_information_then_runtime_error_is_raised(  # noqa: E501
         self,
     ):
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[],
         )
@@ -153,15 +153,15 @@ class TestFiveGNRFProvider:
     def test_given_unit_is_leader_when_set_nrf_information_in_all_relations_then_data_in_application_databag(  # noqa: E501
         self,
     ):
-        nrf_relation_1 = scenario.Relation(
+        nrf_relation_1 = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        nrf_relation_2 = scenario.Relation(
+        nrf_relation_2 = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations=[nrf_relation_1, nrf_relation_2],
         )

--- a/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
+++ b/tests/unit/charms/sdcore_nrf/v0/test_fiveg_nrf_requirer_interface.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch
 
 import pytest
-import scenario
+from ops import testing
 from ops.charm import ActionEvent, CharmBase
 
 from lib.charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFBrokenEvent, NRFRequires
@@ -34,7 +34,7 @@ class TestFiveGNRFRequirer:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFiveGNRFRequirerCharm,
             meta={
                 "name": "nrf-requirer-charm",
@@ -48,14 +48,14 @@ class TestFiveGNRFRequirer:
     def test_given_nrf_information_in_relation_data_when_relation_changed_then_nrf_available_event_emitted(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
             remote_app_data={
                 "url": "http://nrf.com",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 
@@ -68,11 +68,11 @@ class TestFiveGNRFRequirer:
     def test_given_nrf_information_not_in_relation_data_when_relation_changed_then_nrf_available_event_not_emitted(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 
@@ -83,14 +83,14 @@ class TestFiveGNRFRequirer:
     def test_given_invalid_nrf_information_in_relation_data_when_relation_changed_then_nrf_available_event_not_emitted(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
             remote_app_data={
                 "pizza": "steak",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 
@@ -101,14 +101,14 @@ class TestFiveGNRFRequirer:
     def test_given_invalid_nrf_information_in_relation_data_when_relation_changed_then_error_is_logged(  # noqa: E501
         self, caplog
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
             remote_app_data={
                 "pizza": "steak",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 
@@ -119,14 +119,14 @@ class TestFiveGNRFRequirer:
     def test_given_nrf_information_in_relation_data_when_get_nrf_url_is_called_then_expected_url_is_returned(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
             remote_app_data={
                 "url": "http://nrf.com",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 
@@ -140,11 +140,11 @@ class TestFiveGNRFRequirer:
     def test_given_nrf_information_not_in_relation_data_when_get_nrf_url_then_returns_none(  # noqa: E501
         self, caplog
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 
@@ -159,14 +159,14 @@ class TestFiveGNRFRequirer:
     def test_given_nrf_information_in_relation_data_is_not_valid_when_get_nrf_url_then_returns_none_and_error_is_logged(  # noqa: E501
         self, caplog
     ):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
             remote_app_data={
                 "pizza": "steak",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 
@@ -179,11 +179,11 @@ class TestFiveGNRFRequirer:
         assert "Invalid relation data: {'pizza': 'steak'}" in caplog.messages
 
     def test_given_nrf_relation_created_when_relation_broken_then_nrf_broken_event_emitted(self):
-        nrf_relation = scenario.Relation(
+        nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             relations=[nrf_relation],
         )
 

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import NRFOperatorCharm
 
@@ -57,6 +57,6 @@ class NRFUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=NRFOperatorCharm,
         )

--- a/tests/unit/test_charm_certificate_relation_broken.py
+++ b/tests/unit/test_charm_certificate_relation_broken.py
@@ -5,7 +5,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import NRFUnitTestFixtures
 
@@ -13,20 +13,20 @@ from tests.unit.fixtures import NRFUnitTestFixtures
 class TestCharmCertificateRelationBroken(NRFUnitTestFixtures):
     def test_given_container_when_certificates_relation_broken_then_certificate_deleted(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={"certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation],
                 leader=True,

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -4,7 +4,7 @@
 
 import tempfile
 
-import scenario
+from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer, ServiceStatus
 
@@ -14,10 +14,10 @@ from tests.unit.fixtures import NRFUnitTestFixtures
 
 class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_container_not_ready_when_collect_unit_status_then_status_is_waiting(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             leader=True,
         )
@@ -27,11 +27,11 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
         assert state_out.unit_status == WaitingStatus("Waiting for container to be ready")
 
     def test_given_relations_not_created_when_collect_unit_status_then_status_is_blocked(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             leader=True,
         )
@@ -45,15 +45,15 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_certificates_and_nms_relations_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        database_relation = scenario.Relation(
+        database_relation = testing.Relation(
             endpoint="database",
             interface="mongodb_client",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[database_relation],
             leader=True,
@@ -68,19 +68,19 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_nms_relation_not_created_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
-        database_relation = scenario.Relation(
+        database_relation = testing.Relation(
             endpoint="database",
             interface="mongodb_client",
         )
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[database_relation, certificates_relation],
             leader=True,
@@ -93,23 +93,23 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_database_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        database_relation = scenario.Relation(
+        database_relation = testing.Relation(
             endpoint="database",
             interface="mongodb_client",
         )
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[database_relation, certificates_relation, nms_relation],
             leader=True,
@@ -123,23 +123,23 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_database_information_not_available_when_collect_unit_status_then_status_is_waiting(  # noqa: E501
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        database_relation = scenario.Relation(
+        database_relation = testing.Relation(
             endpoint="database",
             interface="mongodb_client",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, database_relation, nms_relation],
             leader=True,
@@ -154,23 +154,23 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_webui_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        database_relation = scenario.Relation(
+        database_relation = testing.Relation(
             endpoint="database",
             interface="mongodb_client",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, database_relation, nms_relation],
             leader=True,
@@ -188,23 +188,23 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_storage_not_attached_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates",
             interface="tls-certificates",
         )
-        database_relation = scenario.Relation(
+        database_relation = testing.Relation(
             endpoint="database",
             interface="mongodb_client",
         )
-        nms_relation = scenario.Relation(
+        nms_relation = testing.Relation(
             endpoint="sdcore_config",
             interface="sdcore_config",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[certificates_relation, database_relation, nms_relation],
             leader=True,
@@ -223,27 +223,27 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="mongodb_client",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf/",
                 source=tempdir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={
@@ -251,7 +251,7 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
                     "certs": certs_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, database_relation, nms_relation],
                 leader=True,
@@ -273,27 +273,27 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="mongodb_client",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf/",
                 source=tempdir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={
@@ -301,7 +301,7 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
                     "certs": certs_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, database_relation, nms_relation],
                 leader=True,
@@ -324,27 +324,27 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="mongodb_client",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf/",
                 source=tempdir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS/",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 layers={"nrf": Layer({"services": {"nrf": {}}})},
@@ -356,7 +356,7 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
                     "certs": certs_mount,
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[certificates_relation, database_relation, nms_relation],
                 leader=True,
@@ -381,11 +381,11 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
     def test_given_no_workload_version_file_when_collect_unit_status_then_workload_version_not_set(  # noqa: E501
         self,
     ):
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             leader=True,
         )
@@ -398,16 +398,16 @@ class TestCharmCollectStatus(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={"workload-version": workload_version_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 leader=True,
             )

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -5,7 +5,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.certificates_helpers import example_cert_and_key
@@ -17,32 +17,32 @@ class TestCharmConfigure(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="data-platform",
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[database_relation, certificates_relation, nms_relation],
                 leader=True,
@@ -71,32 +71,32 @@ class TestCharmConfigure(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="data-platform",
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[database_relation, certificates_relation, nms_relation],
                 leader=True,
@@ -131,32 +131,32 @@ class TestCharmConfigure(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="data-platform",
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[database_relation, certificates_relation, nms_relation],
                 leader=True,
@@ -199,36 +199,36 @@ class TestCharmConfigure(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="data-platform",
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            fiveg_nrf_relation = scenario.Relation(
+            fiveg_nrf_relation = testing.Relation(
                 endpoint="fiveg_nrf",
                 interface="fiveg_nrf",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[
                     database_relation,
@@ -256,32 +256,32 @@ class TestCharmConfigure(NRFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as temp_dir:
-            database_relation = scenario.Relation(
+            database_relation = testing.Relation(
                 endpoint="database",
                 interface="data-platform",
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates",
                 interface="tls-certificates",
             )
-            nms_relation = scenario.Relation(
+            nms_relation = testing.Relation(
                 endpoint="sdcore_config",
                 interface="sdcore_config",
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/etc/nrf",
                 source=temp_dir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=temp_dir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="nrf",
                 can_connect=True,
                 mounts={"config": config_mount, "certs": certs_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 containers=[container],
                 relations=[
                     database_relation,

--- a/tests/unit/test_charm_fiveg_nrf_relation_joined.py
+++ b/tests/unit/test_charm_fiveg_nrf_relation_joined.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 
-import scenario
+from ops import testing
 from ops.pebble import Layer, ServiceStatus
 
 from tests.unit.fixtures import NRFUnitTestFixtures
@@ -12,11 +12,11 @@ class TestCharmGiveGNRFRelatonJoined(NRFUnitTestFixtures):
     def test_given_https_nrf_url_and_service_is_running_when_fiveg_nrf_relation_joined_then_nrf_url_is_in_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_nrf_relation = scenario.Relation(
+        fiveg_nrf_relation = testing.Relation(
             endpoint="fiveg_nrf",
             interface="fiveg_nrf",
         )
-        container = scenario.Container(
+        container = testing.Container(
             name="nrf",
             can_connect=True,
             layers={"nrf": Layer({"services": {"nrf": {}}})},
@@ -24,7 +24,7 @@ class TestCharmGiveGNRFRelatonJoined(NRFUnitTestFixtures):
                 "nrf": ServiceStatus.ACTIVE,
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             containers=[container],
             relations=[fiveg_nrf_relation],
             leader=True,


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use ops.testing instead of scenario. Both have the same API.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
