### PR TITLE
chore: use Juju 3.5 and Microk8s 1.31-strict/stable in the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ lxd init --auto
 
 Install MicroK8s:
 ```shell
-sudo snap install microk8s --channel=1.27-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo usermod -a -G snap_microk8s $USER
 newgrp snap_microk8s
 sudo microk8s enable hostpath-storage
@@ -21,7 +21,7 @@ sudo microk8s enable hostpath-storage
 
 Install Juju and bootstrap a controller on the MicroK8S instance:
 ```shell
-sudo snap install juju --channel=3.1/stable
+sudo snap install juju --channel=3.5/stable
 juju bootstrap microk8s
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 
 # Image
 
-- **nrf**: `ghcr.io/canonical/sdcore-nrf:1.4.1`
+- **nrf**: `ghcr.io/canonical/sdcore-nrf:1.5.2`
 


### PR DESCRIPTION
# Description

Use Juju 3.5 and Microk8s 1.31-strict/stable in the docs

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
