### PR TITLE
feat: add NMS integration with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ juju deploy self-signed-certificates
 
 juju integrate sdcore-nms-k8s:common_database mongodb-k8s:database
 juju integrate sdcore-nms-k8s:auth_database mongodb-k8s:database
+juju integrate sdcore-nms-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:database mongodb-k8s
 juju integrate sdcore-nrf-k8s:sdcore_config sdcore-nms-k8s:sdcore_config
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -51,8 +51,8 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
 ):
     assert ops_test.model
     await _deploy_mongodb(ops_test)
-    await _deploy_nms(ops_test)
     await _deploy_self_signed_certificates(ops_test)
+    await _deploy_nms(ops_test)
     await _deploy_grafana_agent(ops_test)
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
@@ -95,6 +95,7 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy)
     assert ops_test.model
     await _deploy_self_signed_certificates(ops_test)
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_CHARM_NAME)
+    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_CHARM_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
 
@@ -168,11 +169,12 @@ async def _deploy_nms(ops_test: OpsTest):
         channel=NMS_CHARM_CHANNEL,
     )
     await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DB_CHARM_NAME}"
+        relation1=f"{NMS_CHARM_NAME}:common_database", relation2=DB_CHARM_NAME
     )
     await ops_test.model.integrate(
-        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DB_CHARM_NAME}"
+        relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=DB_CHARM_NAME
     )
+    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_CHARM_NAME)
 
 
 async def _deploy_grafana_agent(ops_test: OpsTest):


### PR DESCRIPTION
# Description

This PR adds the NMS integration with the TLS to the integration tests.
TLS certificates integration is mandatory for NMS and the NMS charm does not share the webui address until this relation exists.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
