### PR TITLE
chore: move to channel 6/stable in mongodb

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 DB_CHARM_NAME = "mongodb-k8s"
-DB_CHARM_CHANNEL = "6/beta"
+DB_CHARM_CHANNEL = "6/stable"
 NMS_CHARM_NAME = "sdcore-nms-k8s"
 NMS_CHARM_CHANNEL = "1.5/edge"
 TLS_CHARM_NAME = "self-signed-certificates"
@@ -99,9 +99,6 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, deploy)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
 
-@pytest.mark.skip(
-    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
-)
 @pytest.mark.abort_on_fail
 async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
     assert ops_test.model
@@ -109,9 +106,6 @@ async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, de
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=TIMEOUT)
 
 
-@pytest.mark.skip(
-    reason="Bug in MongoDB: https://github.com/canonical/mongodb-k8s-operator/issues/218"
-)
 @pytest.mark.abort_on_fail
 async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model


### PR DESCRIPTION
# Description

This PR sets the the `6/stable` channel for mongodb charm instead of `6/beta`
https://github.com/canonical/mongodb-k8s-operator/issues/218 seems fixed in `6/stable` so the tests can be restored

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
