### PR TITLE
chore: Bumps project version to 1.6

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v2.2.0
     with:
-      track-name: 1.5
+      track-name: 1.6
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
@@ -68,7 +68,7 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@v2.2.0
     with:
       branch-name: ${{ github.ref_name }}
-      track-name: 1.5
+      track-name: 1.6
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -15,6 +15,7 @@ on:
         description: Name of the charmhub track to publish
         options:
           - '1.5'
+          - '1.6'
           - latest
 
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Charmed Operator for the Aether SD-Core Network Repository Function (NRF) for K8
 # Usage
 
 ```bash
-juju deploy sdcore-nrf-k8s --channel=1.5/edge
-juju deploy mongodb-k8s --trust --channel=6/beta
-juju deploy sdcore-nms-k8s --channel=1.5/edge
+juju deploy sdcore-nrf-k8s --channel=1.6/edge
+juju deploy mongodb-k8s --trust --channel=6/stable
+juju deploy sdcore-nms-k8s --channel=1.6/edge
 juju deploy self-signed-certificates
 
 juju integrate sdcore-nms-k8s:common_database mongodb-k8s:database

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "1.5/edge"
+  default     = "1.6/edge"
 }
 
 variable "config" {


### PR DESCRIPTION
# Description

Bumps project version to `1.6` after creation of `v1.5` release branch

NOTE:
Due to a cyclic dependency between the AMF, NMS and NRF, integration tests still use NMS from `1.5/edge`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
