### PR TITLE
chore: bump nrf rock to v1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 
 # Image
 
-- **nrf**: `ghcr.io/canonical/sdcore-nrf:1.5.2`
+- **nrf**: `ghcr.io/canonical/sdcore-nrf:1.6.2`
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,7 +22,7 @@ resources:
   nrf-image:
     type: oci-image
     description: OCI image for SD-Core nrf
-    upstream-source: ghcr.io/canonical/sdcore-nrf:1.6.1
+    upstream-source: ghcr.io/canonical/sdcore-nrf:1.6.2
 
 storage:
   config:


### PR DESCRIPTION
# Description

Bump the underlying workload to the latest upstream release: v1.6.2

## Reference
- https://github.com/omec-project/nrf/releases/tag/v1.6.2

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
