### PR TITLE
chore: use base instead of series in charm deployment in integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -41,7 +41,7 @@ async def deploy(ops_test: OpsTest, request):
         charm,
         resources=resources,
         application_name=APP_NAME,
-        series="noble",
+        base=SDCORE_CHARMS_BASE,
     )
 
 


### PR DESCRIPTION
# Description

This PR removes a workaround and specifies the base instead of series for charms that support 2 bases.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
