### PR TITLE
chore: remove unused config file params

### DIFF
--- a/src/templates/nrfcfg.yaml.j2
+++ b/src/templates/nrfcfg.yaml.j2
@@ -2,9 +2,6 @@ configuration:
   MongoDBName: {{ database_name }}
   MongoDBUrl: {{ database_url }}
   mongoDBStreamEnable: true
-  mongodb:
-    name: {{ database_name }}
-    url: {{ database_url }}
   nfKeepAliveTime: 60
   nfProfileExpiryEnable: true
   webuiUri: {{ webui_url }}

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -2,9 +2,6 @@ configuration:
   MongoDBName: free5gc
   MongoDBUrl: http://dummy
   mongoDBStreamEnable: true
-  mongodb:
-    name: free5gc
-    url: http://dummy
   nfKeepAliveTime: 60
   nfProfileExpiryEnable: true
   webuiUri: some-webui:7890


### PR DESCRIPTION
# Description

MongoDB information is duplicated in the configuration file. Turns out that in the NRF, the parameters are called `MongoDBName` and `MongoDBUrl`. We can remove the `mongodb` field and it's nested strutcs.

See the upstream code https://github.com/omec-project/nrf/blob/main/factory/config.go#L46

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
